### PR TITLE
add missing package due to java-11 ubi package update

### DIFF
--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -28,7 +28,7 @@ ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script
 # Also set up permissions for user `1001`
-RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} \
+RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} tzdata-java \
     && microdnf update \
     && microdnf clean all \
     && mkdir /deployments \

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -28,7 +28,7 @@ ARG RUN_JAVA_VERSION=1.3.8
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 # Install java and the run-java script
 # Also set up permissions for user `1001`
-RUN microdnf install curl ca-certificates ${JAVA_PACKAGE} tzdata-java \
+RUN microdnf install curl ca-certificates tzdata-java ${JAVA_PACKAGE} \
     && microdnf update \
     && microdnf clean all \
     && mkdir /deployments \


### PR DESCRIPTION
Because the new JAVA package removed specific classes.

The workshop needs to be fixed. 

The PR fixed the issue. However, we need to figure out how to use a reliable JAVA package in the future.

A related issue -> https://github.com/quarkusio/quarkus/discussions/34907 
